### PR TITLE
chore: update ConfluxScan link

### DIFF
--- a/src/config/chainConfig/cfx.js
+++ b/src/config/chainConfig/cfx.js
@@ -4,7 +4,7 @@ import {ChainId} from './chainId'
 
 export const CFX_MAIN_CHAINID = ChainId.CFX
 export const CFX_MAINNET = getLocalRPC(CFX_MAIN_CHAINID, 'https://evm.confluxrpc.com')
-export const CFX_MAIN_EXPLORER = 'https://evm.confluxscan.io'
+export const CFX_MAIN_EXPLORER = 'https://evm.confluxscan.net'
 
 export const testTokenList = []
 


### PR DESCRIPTION
Official Conflux blockchain explorer ConfluxScan is now live with new domain links. This PR updates the ConfluxScan link.

Check the official announcement here: https://forum.conflux.fun/t/confluxscan-domain-update-announcement-march-28-2025/21920